### PR TITLE
Updating handler names for interface changes

### DIFF
--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -28,7 +28,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 // forge test --match-test test_doomsday_bsmTester_updateEscrow_always_works_0 -vvv 
 function test_doomsday_bsmTester_updateEscrow_always_works_0() public {
 
-    bsmTester_buyEbtcWithAsset(3);
+    bsmTester_sellAsset(3);
 
     switch_asset(1);
 
@@ -46,7 +46,7 @@ function test_doomsday_bsmTester_updateEscrow_always_works_0() public {
  // forge test --match-test test_property_accounting_is_sound_0 -vvv 
 function test_property_accounting_is_sound_0() public {
 
-    bsmTester_buyEbtcWithAsset(1);
+    bsmTester_sellAsset(1);
 
     switch_asset(1);
 
@@ -61,7 +61,7 @@ function test_property_accounting_is_sound_0() public {
 // forge test --match-test test_inlined_withdrawProfitTest_1 -vvv 
 function test_inlined_withdrawProfitTest_1() public {
 
-    bsmTester_buyEbtcWithAsset(1);
+    bsmTester_sellAsset(1);
 
     escrow_depositToExternalVault_rekt(1,0);
 

--- a/test/recon/TargetFunctions.sol
+++ b/test/recon/TargetFunctions.sol
@@ -11,11 +11,11 @@ import {InlinedTests} from "./targets/InlinedTests.sol";
 import {ManagersTargets} from "./targets/ManagersTargets.sol";
 
 abstract contract TargetFunctions is AdminTargets, InlinedTests, ManagersTargets {
-    function bsmTester_buyAssetWithEbtc(uint256 _ebtcAmountIn) public updateGhosts {
-        bsmTester.buyAsset(_ebtcAmountIn, address(this));
+    function bsmTester_buyAsset(uint256 _ebtcAmountIn) public updateGhosts asActor {
+        bsmTester.buyAsset(_ebtcAmountIn, _getActor());
     }
 
-    function bsmTester_buyEbtcWithAsset(uint256 _assetAmountIn) public updateGhosts {
-        bsmTester.sellAsset(_assetAmountIn, address(this));
+    function bsmTester_sellAsset(uint256 _assetAmountIn) public updateGhosts asActor {
+        bsmTester.sellAsset(_assetAmountIn, _getActor());
     }
 }

--- a/test/recon/targets/AdminTargets.sol
+++ b/test/recon/targets/AdminTargets.sol
@@ -82,11 +82,11 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         bsmTester.pause();
     }
 
-    function bsmTester_setFeeToBuyAsset(uint256 _feeToBuyAssetBPS) public updateGhosts asTechops {
+    function bsmTester_setFeeToBuy(uint256 _feeToBuyAssetBPS) public updateGhosts asTechops {
         bsmTester.setFeeToBuy(_feeToBuyAssetBPS);
     }
 
-    function bsmTester_setFeeToBuyEbtc(uint256 _feeToBuyEbtcBPS) public updateGhosts asTechops {
+    function bsmTester_setFeeToSell(uint256 _feeToBuyEbtcBPS) public updateGhosts asTechops {
         bsmTester.setFeeToSell(_feeToBuyEbtcBPS);
     }
 


### PR DESCRIPTION
Fixes handler names in invariant suite that used names different from the functions they're calling on the target contract.