### PR TITLE
Additional TWAP properties

### DIFF
--- a/test/recon-twap/BeforeAfter.sol
+++ b/test/recon-twap/BeforeAfter.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+pragma solidity ^0.8.0;
+
+import {Setup} from "./Setup.sol";
+
+// ghost variables for tracking state variable values before and after function calls
+abstract contract BeforeAfter is Setup {
+    struct Vars {
+        uint128 accumulator;
+        uint64 lastObserved;
+    }
+
+    Vars internal _before;
+    Vars internal _after;
+
+    modifier updateGhosts() {
+        __before();
+        _;
+        __after();
+    }
+
+    function __before() internal {
+        _before.accumulator = twapWeightedObserver.getLatestAccumulator();
+        _before.lastObserved = twapWeightedObserver.getData().lastObserved;
+    }
+
+    function __after() internal {
+        _after.accumulator = twapWeightedObserver.getLatestAccumulator();
+        _after.lastObserved = twapWeightedObserver.getData().lastObserved;
+    }
+}

--- a/test/recon-twap/Properties.sol
+++ b/test/recon-twap/Properties.sol
@@ -13,4 +13,22 @@ abstract contract Properties is Setup, Asserts {
 
         eq(valueFromActivePool, valueFromTwap, "Observe values should be the same");
     }
+
+    // If we get to the end of the week and data doesn't change,
+    // then every new second and observation will result in the same value
+    function property_observation_consistent_past_update_period() public {
+        if (
+            // check that it's been a week since the last observation
+            block.timestamp - twapWeightedObserver.getData().lastObserved >= twapWeightedObserver.PERIOD() && 
+            // check that the data hasn't changed since the last observation
+            cachedLastObservedAverage == twapWeightedObserver.getData().lastObservedAverage
+            ) 
+        {
+            // make a new observation
+            activePoolObserver.observe();
+            uint128 newLastObservedAverage = twapWeightedObserver.getData().lastObservedAverage;
+
+            eq(newLastObservedAverage, cachedLastObservedAverage, "Observed value should be the same as the last observed average");
+        }
+    }
 }

--- a/test/recon-twap/Properties.sol
+++ b/test/recon-twap/Properties.sol
@@ -3,9 +3,9 @@
 pragma solidity ^0.8.0;
 
 import {Asserts} from "@chimera/Asserts.sol";
-import {Setup} from "./Setup.sol";
+import { BeforeAfter } from "./BeforeAfter.sol";
 
-abstract contract Properties is Setup, Asserts {
+abstract contract Properties is BeforeAfter, Asserts {
 
     function property_observe_always_same() public {
         uint256 valueFromActivePool = activePoolObserver.observe();
@@ -29,6 +29,17 @@ abstract contract Properties is Setup, Asserts {
             uint128 newLastObservedAverage = twapWeightedObserver.getData().lastObservedAverage;
 
             eq(newLastObservedAverage, cachedLastObservedAverage, "Observed value should be the same as the last observed average");
+        }
+    }
+
+    // Any time the accumulator increases, the time / acc should increase at the same rate
+    function property_time_accumulator_ratio_is_correct() public {
+        uint256 ratioDelta = (_after.lastObserved / _after.accumulator) - (_before.lastObserved / _before.accumulator);
+        uint256 accumulatorDelta = _after.accumulator - _before.accumulator;
+
+        // Precondition: the accumulator has increased
+        if(_before.accumulator < _after.accumulator) {
+            eq(accumulatorDelta, ratioDelta, "Accumulator should increase at the same rate as the time / acc");
         }
     }
 }

--- a/test/recon-twap/Setup.sol
+++ b/test/recon-twap/Setup.sol
@@ -11,6 +11,8 @@ import {TwapWeightedObserver} from "./helpers/TwapWeightedObserver.sol";
 abstract contract Setup is BaseSetup {
     ActivePoolObserver activePoolObserver;
     TwapWeightedObserver twapWeightedObserver;
+
+    uint256 internal cachedLastObservedAverage;
     
     function setup() internal virtual override {
       twapWeightedObserver = new TwapWeightedObserver(100);

--- a/test/recon-twap/TargetFunctions.sol
+++ b/test/recon-twap/TargetFunctions.sol
@@ -9,6 +9,9 @@ import {vm} from "@chimera/Hevm.sol";
 abstract contract TargetFunctions is BaseTargetFunctions, Properties {
 
     function twapWeightedObserver_setValueAndUpdate(uint128 _value) public {
+        // require that the value is greater than 0 or else it would cause false positives in the doomsday properties
+        require(_value > 0, "Value must be greater than 0");
+
         vm.prank(address(twapWeightedObserver));
         twapWeightedObserver.setValueAndUpdate(_value);
     }
@@ -21,11 +24,17 @@ abstract contract TargetFunctions is BaseTargetFunctions, Properties {
         // cache the last observed average before updating for comparison
         cachedLastObservedAverage = twapWeightedObserver.getData().lastObservedAverage;
         twapWeightedObserver.observe();
-    }
+    } 
 
     function activePoolObserver_observe() public {
         // cache the last observed average before updating for comparison
         cachedLastObservedAverage = twapWeightedObserver.getData().lastObservedAverage;
-        activePoolObserver.observe();
+        try activePoolObserver.observe() returns (uint256 currentValue) {
+            // Doomsday: if observe returns 0, RateLimitingConstraint::canMint prevents minting new eBTC
+            gt(currentValue, 0, "observe should never return 0");
+        } catch {
+            // Doomsday: if observe reverts, RateLimitingConstraint::canMint sellAsset fails
+            t(false, "observe should never revert");
+        }
     }
 }

--- a/test/recon-twap/TargetFunctions.sol
+++ b/test/recon-twap/TargetFunctions.sol
@@ -16,4 +16,16 @@ abstract contract TargetFunctions is BaseTargetFunctions, Properties {
     function twapWeightedObserver_update() public {
         twapWeightedObserver.update();
     }
+
+    function twapWeightedObserver_observe() public {
+        // cache the last observed average before updating for comparison
+        cachedLastObservedAverage = twapWeightedObserver.getData().lastObservedAverage;
+        twapWeightedObserver.observe();
+    }
+
+    function activePoolObserver_observe() public {
+        // cache the last observed average before updating for comparison
+        cachedLastObservedAverage = twapWeightedObserver.getData().lastObservedAverage;
+        activePoolObserver.observe();
+    }
 }


### PR DESCRIPTION
Add the following properties: 
- `property_observation_consistent_past_update_period` - If the end of the week is reached and data doesn't change, then every new second and observation will result in the same value
- `property_time_accumulator_ratio_is_correct` - Any time the accumulator increases, the time / acc should increase at the same rate
- doomsday properties that check that `ActivePoolObserver::observe` never reverts and never returns a 0 value as it would cause issues with the checks in `canMint`