### PR TITLE
Clamping in twapWeightedObserver_setValueAndUpdate to max eBTC…

### DIFF
--- a/test/recon-twap/TargetFunctions.sol
+++ b/test/recon-twap/TargetFunctions.sol
@@ -10,7 +10,7 @@ abstract contract TargetFunctions is BaseTargetFunctions, Properties {
 
     function twapWeightedObserver_setValueAndUpdate(uint128 _value) public {
         // clamp value using the max possible eBTC debt in the ActivePool
-        _value %= 21 * 10e24;
+        _value %= 21e24;
 
         // require that the value is greater than 0 or else it would cause false positives in the doomsday properties
         require(_value > 0, "Value must be greater than 0");

--- a/test/recon-twap/TargetFunctions.sol
+++ b/test/recon-twap/TargetFunctions.sol
@@ -9,6 +9,9 @@ import {vm} from "@chimera/Hevm.sol";
 abstract contract TargetFunctions is BaseTargetFunctions, Properties {
 
     function twapWeightedObserver_setValueAndUpdate(uint128 _value) public {
+        // clamp value using the max possible eBTC debt in the ActivePool
+        _value %= 21 * 10e24;
+
         // require that the value is greater than 0 or else it would cause false positives in the doomsday properties
         require(_value > 0, "Value must be greater than 0");
 


### PR DESCRIPTION
This fixes an issue in `feat/twap-additional-properties` that was causing the `activePoolObserver_observe` doomsday property to fail because there was no clamping of the `_value` in `twapWeightedObserver_setValueAndUpdate` which would lead to `getLatestAccumulator` reverting when the value was too large. 

This change clamps the `_value` to the max supply of BTC with 18 decimal precision 21e24.

Latest run here: https://getrecon.xyz/shares/9b7295d7-c40b-49cd-9b21-fb94cd179e7c