### PR TITLE
Fix all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 ## cd code && solc-select use 0.8.20 && cd packages/contracts/ && yarn echidna --test-mode assertion --test-limit 100000
 
 ## Run MEDUSA with (if you have already ran tests and compilation)
-## cd code && solc-select use 0.8.25 && medusa fuzz
+## cd code && solc-select use 0.8.29 && medusa fuzz
 
 ## If you've never built the repo
 ## Run ECHIDNA with
@@ -59,7 +59,7 @@ RUN pip3 install solc-select
 RUN echo "[$(date)] Install latest solidity versions"
 RUN solc-select install 0.8.17
 RUN solc-select install 0.8.20
-RUN solc-select install 0.8.25
+RUN solc-select install 0.8.29
 
 ## NOTE: You could use something else here, just don't want to install a ton of compilers for no reason
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-solc_version= '0.8.25'
+solc_version= '0.8.29'
 fuzz = { runs = 1_000 }
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/scripts/ObserveCompare.s.sol
+++ b/scripts/ObserveCompare.s.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "forge-std/Script.sol";
 import {IActivePoolObserver} from "../src/Dependencies/IActivePoolObserver.sol";

--- a/src/ActivePoolObserver.sol
+++ b/src/ActivePoolObserver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {ITwapWeightedObserver} from "./Dependencies/ITwapWeightedObserver.sol";
 

--- a/src/AssetChainlinkAdapter.sol
+++ b/src/AssetChainlinkAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {AggregatorV3Interface} from "./Dependencies/AggregatorV3Interface.sol";
 
@@ -40,6 +40,12 @@ contract AssetChainlinkAdapter is AggregatorV3Interface {
     int256 internal immutable ASSET_USD_PRECISION;
     int256 internal immutable BTC_USD_PRECISION;
 
+    error WrongDecimals();
+
+    error OracleRound();
+    error OracleAnswer();
+    error OracleStale();
+
     /**
      * @notice Contract constructor
      * @param _assetUsdClFeed AggregatorV3Interface contract feed for Asset -> USD
@@ -58,8 +64,8 @@ contract AssetChainlinkAdapter is AggregatorV3Interface {
         BTC_FEED_FRESHNESS = _maxBtcFreshness;
         INVERTED = _inverted;
 
-        require(ASSET_USD_CL_FEED.decimals() <= MAX_DECIMALS);
-        require(BTC_USD_CL_FEED.decimals() <= MAX_DECIMALS);
+        require(ASSET_USD_CL_FEED.decimals() <= MAX_DECIMALS, WrongDecimals());
+        require(BTC_USD_CL_FEED.decimals() <= MAX_DECIMALS, WrongDecimals());
 
         ASSET_USD_PRECISION = int256(10 ** ASSET_USD_CL_FEED.decimals());
         BTC_USD_PRECISION = int256(10 ** BTC_USD_CL_FEED.decimals());
@@ -99,9 +105,9 @@ contract AssetChainlinkAdapter is AggregatorV3Interface {
     ) private view returns (int256 answer, uint256 updatedAt) {
         uint80 feedRoundId;
         (feedRoundId, answer, , updatedAt, ) = _feed.latestRoundData();
-        require(feedRoundId > 0);
-        require(answer > 0);
-        require((block.timestamp - updatedAt) <= maxFreshness);
+        require(feedRoundId > 0, OracleRound());
+        require(answer > 0, OracleAnswer());
+        require((block.timestamp - updatedAt) <= maxFreshness, OracleStale());
     }
 
     /// @dev Needed because we inherit from AggregatorV3Interface

--- a/src/BSMDeployer.sol
+++ b/src/BSMDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "./EbtcBSM.sol";
 import "./ERC4626Escrow.sol";

--- a/src/BaseEscrow.sol
+++ b/src/BaseEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import { AuthNoOwner } from "./Dependencies/AuthNoOwner.sol";
 import { IEscrow } from "./Dependencies/IEscrow.sol";
@@ -18,6 +18,8 @@ contract BaseEscrow is AuthNoOwner, IEscrow {
     uint256 public totalAssetsDeposited;
 
     error CallerNotBSM();
+    error Token();
+    error LossCheck();
 
     /// @notice Modifier to restrict function calls to the BSM
     modifier onlyBSM() {
@@ -87,7 +89,7 @@ contract BaseEscrow is AuthNoOwner, IEscrow {
         if (profit > 0) {
             _withdrawProfit(profit);
             // INVARIANT: total balance must be >= deposit amount
-            require(_totalBalance() >= totalAssetsDeposited);
+            require(_totalBalance() >= totalAssetsDeposited, LossCheck());
             emit ProfitClaimed(profit);
         }        
     }
@@ -160,7 +162,7 @@ contract BaseEscrow is AuthNoOwner, IEscrow {
     }
 
     function _claimTokens(address token, uint256 amount) internal virtual {
-        require(token != address(ASSET_TOKEN));
+        require(token != address(ASSET_TOKEN), Token());
         if (amount > 0) {
             IERC20(token).safeTransfer(FEE_RECIPIENT, amount);
         }

--- a/src/BaseEscrow.sol
+++ b/src/BaseEscrow.sol
@@ -74,8 +74,9 @@ contract BaseEscrow is AuthNoOwner, IEscrow {
 
     /// @notice withdraw profit to FEE_RECIPIENT
     /// @param _profitAmount The amount of profit to withdraw
-    function _withdrawProfit(uint256 _profitAmount) internal virtual {
+    function _withdrawProfit(uint256 _profitAmount) internal virtual returns (uint256){
         ASSET_TOKEN.safeTransfer(FEE_RECIPIENT, _profitAmount);
+        return _profitAmount;
     }
 
     /// @notice Prepares the escrow for migration
@@ -87,7 +88,7 @@ contract BaseEscrow is AuthNoOwner, IEscrow {
     function _claimProfit() internal {
         uint256 profit = feeProfit();
         if (profit > 0) {
-            _withdrawProfit(profit);
+            uint256 profitWithdrawn = _withdrawProfit(profit);
             // INVARIANT: total balance must be >= deposit amount
             require(_totalBalance() >= totalAssetsDeposited, LossCheck());
             emit ProfitClaimed(profit);

--- a/src/Dependencies/AggregatorV3Interface.sol
+++ b/src/Dependencies/AggregatorV3Interface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 // solhint-disable-next-line interface-starts-with-i
 interface AggregatorV3Interface {

--- a/src/Dependencies/Auth.sol
+++ b/src/Dependencies/Auth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 import {Authority} from "./Authority.sol";
 

--- a/src/Dependencies/AuthNoOwner.sol
+++ b/src/Dependencies/AuthNoOwner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 import {Authority} from "./Authority.sol";
 

--- a/src/Dependencies/Authority.sol
+++ b/src/Dependencies/Authority.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 /// @notice A generic interface for a contract which provides authorization data to an Auth instance.
 /// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/auth/Auth.sol)

--- a/src/Dependencies/EnumerableSet.sol
+++ b/src/Dependencies/EnumerableSet.sol
@@ -2,7 +2,7 @@
 // OpenZeppelin Contracts (last updated v4.8.0) (utils/structs/EnumerableSet.sol)
 // This file was procedurally generated from scripts/generate/templates/EnumerableSet.js.
 
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 /**
  * @dev Library for managing

--- a/src/Dependencies/Governor.sol
+++ b/src/Dependencies/Governor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 import {EnumerableSet} from "./EnumerableSet.sol";
 import {Authority} from "./Auth.sol";

--- a/src/Dependencies/IActivePoolObserver.sol
+++ b/src/Dependencies/IActivePoolObserver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 interface IActivePoolObserver {
     function observe() external view returns (uint256);

--- a/src/Dependencies/IConstraint.sol
+++ b/src/Dependencies/IConstraint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 interface IConstraint {
     event ConstraintUpdated(address indexed oldConstraint, address indexed newConstraint);

--- a/src/Dependencies/IERC4626Escrow.sol
+++ b/src/Dependencies/IERC4626Escrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 import {IEscrow} from "./IEscrow.sol";
 

--- a/src/Dependencies/IEbtcBSM.sol
+++ b/src/Dependencies/IEbtcBSM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 interface IEbtcBSM {
     event EscrowUpdated(address indexed oldVault, address indexed newVault);

--- a/src/Dependencies/IEbtcToken.sol
+++ b/src/Dependencies/IEbtcToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 interface IEbtcToken {
     function mint(address _account, uint256 _amount) external;

--- a/src/Dependencies/IEscrow.sol
+++ b/src/Dependencies/IEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 interface IEscrow {
     event ProfitClaimed(uint256 profitAmount);

--- a/src/Dependencies/IRolesAuthority.sol
+++ b/src/Dependencies/IRolesAuthority.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 import "./EnumerableSet.sol";
 

--- a/src/Dependencies/ITwapWeightedObserver.sol
+++ b/src/Dependencies/ITwapWeightedObserver.sol
@@ -1,5 +1,5 @@
 // SPDX-License Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 interface ITwapWeightedObserver {
     // NOTE: Packing manually is cheaper, but this is simpler to understand and follow

--- a/src/Dependencies/RolesAuthority.sol
+++ b/src/Dependencies/RolesAuthority.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.25;
+pragma solidity 0.8.29;
 
 import {IRolesAuthority} from "./IRolesAuthority.sol";
 import {Auth, Authority} from "./Auth.sol";

--- a/src/DummyConstraint.sol
+++ b/src/DummyConstraint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {IConstraint} from "./Dependencies/IConstraint.sol";
 

--- a/src/ERC4626Escrow.sol
+++ b/src/ERC4626Escrow.sol
@@ -111,9 +111,9 @@ contract ERC4626Escrow is BaseEscrow, IERC4626Escrow {
 
     /// @notice Overrides _withdrawProfit from BaseEscrow to manage liquidity from the external vault
     /// @param _profitAmount The amount of profit to withdraw
-    function _withdrawProfit(uint256 _profitAmount) internal override {
+    function _withdrawProfit(uint256 _profitAmount) internal override returns (uint256) {
         uint256 redeemedAmount = _ensureLiquidity(_profitAmount);
-        super._withdrawProfit(redeemedAmount);
+        return super._withdrawProfit(redeemedAmount);
     }
 
     /// @notice Preview the amount of assets that would be withdrawn for a given amount of shares

--- a/src/ERC4626Escrow.sol
+++ b/src/ERC4626Escrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {BaseEscrow} from "./BaseEscrow.sol";
 import {IERC4626Escrow} from "./Dependencies/IERC4626Escrow.sol";
@@ -145,7 +145,7 @@ contract ERC4626Escrow is BaseEscrow, IERC4626Escrow {
     }
 
     function _claimTokens(address token, uint256 amount) internal override {
-        require(token != address(EXTERNAL_VAULT));
+        require(token != address(EXTERNAL_VAULT), Token());
         super._claimTokens(token, amount);
     }
 

--- a/src/ERC4626Escrow.sol
+++ b/src/ERC4626Escrow.sol
@@ -88,6 +88,13 @@ contract ERC4626Escrow is BaseEscrow, IERC4626Escrow {
             }
             // amountRedeemed can be less than deficit because of rounding
             _amountRedeemed = liquidBalance + redeemed;
+
+            /// @audit Some vaults (most OOS) do not accrue their assets in `convertToShares`
+            /// This can cause `redeem` to withdraw more than requested
+            /// To prevent abuse, we cap at deficit
+            if(redeemed > deficit) {
+                _amountRedeemed = liquidBalance + deficit; // Cap for edge case
+            }
         } else {
             // We have liquid amount so we return it
             _amountRedeemed = _amountRequired;

--- a/src/EbtcBSM.sol
+++ b/src/EbtcBSM.sol
@@ -257,9 +257,9 @@ contract EbtcBSM is IEbtcBSM, Pausable, Initializable, AuthNoOwner {
 
         _checkBuyAssetConstraints(ebtcAmountInAssetPrecision);
 
-        EBTC_TOKEN.burn(msg.sender, _ebtcAmountIn);
-
         totalMinted -= _ebtcAmountIn;
+
+        EBTC_TOKEN.burn(msg.sender, _ebtcAmountIn);
 
         uint256 redeemedAmount = escrow.onWithdraw(
             ebtcAmountInAssetPrecision

--- a/src/EbtcBSM.sol
+++ b/src/EbtcBSM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {AuthNoOwner} from "./Dependencies/AuthNoOwner.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";

--- a/src/EbtcBSM.sol
+++ b/src/EbtcBSM.sol
@@ -213,30 +213,31 @@ contract EbtcBSM is IEbtcBSM, Pausable, Initializable, AuthNoOwner {
     ) internal returns (uint256 _ebtcAmountOut) { // ebtc precision
         if (_assetAmountIn == 0) revert ZeroAmount();
         if (_recipient == address(0)) revert InvalidRecipientAddress();
+
         uint256 assetAmountInNoFee = _assetAmountIn - _feeAmount;
 
         // Convert _assetAmountIn to ebtc precision (1e18)
         _ebtcAmountOut = _toEbtcPrecision(assetAmountInNoFee);
-
-        _checkMintingConstraints(_ebtcAmountOut);
-
-        totalMinted += _ebtcAmountOut;
-
-        // INVARIANT: _assetAmountIn >= _ebtcAmountOut
-        ASSET_TOKEN.safeTransferFrom(
-            msg.sender,
-            address(escrow),
-            _assetAmountIn // asset precision
-        );
-        // assetAmountInNoFee = _assetAmountIn - _feeAmount (asset precision)
-        escrow.onDeposit(assetAmountInNoFee);
 
         // slippage check
         if (_ebtcAmountOut < _minOutAmount) {
             revert BelowExpectedMinOutAmount(_minOutAmount, _ebtcAmountOut);
         }
 
+        _checkMintingConstraints(_ebtcAmountOut);
+
+        totalMinted += _ebtcAmountOut;
+
         EBTC_TOKEN.mint(_recipient, _ebtcAmountOut);
+
+        escrow.onDeposit(assetAmountInNoFee);
+
+        // INVARIANT: _assetAmountIn >= _ebtcAmountOut
+        ASSET_TOKEN.safeTransferFrom(
+            msg.sender,
+            address(escrow),
+            _assetAmountIn // asset precision
+        );       
 
         emit AssetSold(_assetAmountIn, _ebtcAmountOut, _feeAmount);
     }

--- a/src/OraclePriceConstraint.sol
+++ b/src/OraclePriceConstraint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {AuthNoOwner} from "./Dependencies/AuthNoOwner.sol";
 import {IConstraint} from "./Dependencies/IConstraint.sol";

--- a/src/RateLimitingConstraint.sol
+++ b/src/RateLimitingConstraint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {AuthNoOwner} from "./Dependencies/AuthNoOwner.sol";
 import {IConstraint} from "./Dependencies/IConstraint.sol";

--- a/test/BSMBase.sol
+++ b/test/BSMBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "forge-std/Test.sol";
 import "@openzeppelin/contracts/mocks/token/ERC4626Mock.sol";

--- a/test/BSMTestBase.sol
+++ b/test/BSMTestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "forge-std/Test.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/test/BuyAssetTests.t.sol
+++ b/test/BuyAssetTests.t.sol
@@ -28,20 +28,23 @@ contract BuyAssetTests is BSMTestBase {
         _checkEbtcBalance(testMinter, ebtcAmount);
         _checkEbtcBalance(testBuyer, buyerBalance);
 
+        uint256 expectedOut = (buyAmount * _assetTokenPrecision() / 1e18);
+        uint256 expectedEbtcBurn = expectedOut * 1e18 / _assetTokenPrecision();
+
         // TEST: make sure preview is correct
-        assertEq(bsmTester.previewBuyAsset(buyAmount), assetTokenAmount / 2);
+        assertEq(bsmTester.previewBuyAsset(buyAmount), expectedOut);
 
         vm.recordLogs();
         vm.prank(testBuyer);
 
-        assertEq(bsmTester.buyAsset(buyAmount, testBuyer, 0), assetTokenAmount / 2);
+        assertEq(bsmTester.buyAsset(buyAmount, testBuyer, 0), expectedOut);
         Vm.Log[] memory entries = vm.getRecordedLogs();
 
         assertEq(entries[0].topics[0], keccak256("Transfer(address,address,uint256)"));
         assertEq(entries[1].topics[0], keccak256("Transfer(address,address,uint256)"));
         assertEq(entries[2].topics[0], keccak256("AssetBought(uint256,uint256,uint256)"));
-        _checkAssetTokenBalance(testBuyer, assetTokenAmount / 2);
-        _checkEbtcBalance(testBuyer, buyerBalance - buyAmount);
+        _checkAssetTokenBalance(testBuyer, expectedOut);
+        _checkEbtcBalance(testBuyer, buyerBalance - expectedEbtcBurn);
     }
 
     function testBuyAssetFee(

--- a/test/BuyAssetTests.t.sol
+++ b/test/BuyAssetTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import "./BSMTestBase.sol";

--- a/test/ChainlinkAdapterTests.t.sol
+++ b/test/ChainlinkAdapterTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "forge-std/Test.sol";
 import {AssetChainlinkAdapter, AggregatorV3Interface} from "../src/AssetChainlinkAdapter.sol";

--- a/test/EbtcBsmTests.t.sol
+++ b/test/EbtcBsmTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "./BSMTestBase.sol";
 import "../src/DummyConstraint.sol";

--- a/test/EscrowTests.t.sol
+++ b/test/EscrowTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "./BSMTestBase.sol";
 import "./mocks/MockAssetToken.sol";

--- a/test/ExternalLendingTests.t.sol
+++ b/test/ExternalLendingTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "@openzeppelin/contracts/mocks/token/ERC4626Mock.sol";
 import {ERC4626Escrow} from "../src/ERC4626Escrow.sol";

--- a/test/GovernanceTests.t.sol
+++ b/test/GovernanceTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "./BSMTestBase.sol";
 import "../src/RateLimitingConstraint.sol";

--- a/test/MigrateVaultTests.t.sol
+++ b/test/MigrateVaultTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "./BSMTestBase.sol";
 import "../src/BaseEscrow.sol";

--- a/test/SellAssetTests.t.sol
+++ b/test/SellAssetTests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "./BSMTestBase.sol";
 import {OraclePriceConstraint} from"../src/OraclePriceConstraint.sol";

--- a/test/mocks/MockActivePoolObserver.sol
+++ b/test/mocks/MockActivePoolObserver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 

--- a/test/mocks/MockAssetOracle.sol
+++ b/test/mocks/MockAssetOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {AggregatorV3Interface} from "../../src/Dependencies/AggregatorV3Interface.sol";
 

--- a/test/mocks/MockAssetToken.sol
+++ b/test/mocks/MockAssetToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 

--- a/test/recon-core/CryticToFoundry.sol
+++ b/test/recon-core/CryticToFoundry.sol
@@ -25,4 +25,15 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     function test_crytic() public {
         bsmTester_updateEscrow();
     }
+
+    // forge test --match-test test_property_total_minted_eq_total_asset_deposits_0 -vvv 
+    function test_property_total_minted_eq_total_asset_deposits_0() public {
+
+        bsmTester_sellAsset(2);
+
+        bsmTester_buyAsset(10000009564);
+
+        property_total_minted_eq_total_asset_deposits();
+
+    }
 }

--- a/test/recon-core/mocks/MockERC20.sol
+++ b/test/recon-core/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.29;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/test/recon-core/targets/PreviewTests.sol
+++ b/test/recon-core/targets/PreviewTests.sol
@@ -26,4 +26,25 @@ abstract contract PreviewTests is BaseTargetFunctions, Properties {
 
         eq(realOut, amtOut, "equivalence_bsm_previewSellAsset");
     }
+
+    // Feeless comparison
+    function equivalence_bsm_previewBuyAssetNoFee(uint256 _ebtcAmountIn) public stateless {
+        require(escrow.totalBalance() > 1e18, "Min bal"); // Should not matter
+
+        uint256 amtOut = bsmTester.previewBuyAssetNoFee(_ebtcAmountIn);
+
+        vm.prank(_getActor());
+        uint256 realOut = bsmTester.buyAssetNoFee(_ebtcAmountIn, _getActor(), 0);
+
+        eq(realOut, amtOut, "equivalence_bsm_previewBuyAsset");
+    }
+
+    function equivalence_bsm_previewSellAssetNoFee(uint256 _assetAmountIn) public stateless {
+        uint256 amtOut = bsmTester.previewSellAssetNoFee(_assetAmountIn);
+
+        vm.prank(_getActor());
+        uint256 realOut = bsmTester.sellAssetNoFee(_assetAmountIn, _getActor(), 0);
+
+        eq(realOut, amtOut, "equivalence_bsm_previewSellAsset");
+    }
 }


### PR DESCRIPTION
## Reasoning

I'm sending this PR to fix issues discussed here:

Diff Review Notes:
https://github.com/Recon-Fuzz/Badger-Ongoing/issues/9

Findings Report:
https://github.com/Recon-Fuzz/Badger-Ongoing/issues/10

## Code changes

Please see different branches for each fix:
- [`fix-cei`](https://github.com/GalloDaSballo/ebtc-bsm/tree/fix-cei) attempts to be CEI conformant, also by order of risk, where eBTC > Escrow > Collateral
- [`fix-ebtc-minted-rounding`](https://github.com/GalloDaSballo/ebtc-bsm/tree/fix-ebtc-minted-rounding): fixes how the rounding was applied so it's applied to asset (which can have lower decimals)
- [`fix-excess-withdraw`](https://github.com/GalloDaSballo/ebtc-bsm/tree/fix-excess-withdraw): fixes the edge case of withdrawing too much by applying a simple to read `min`
- [`fix-solidity-errors`](https://github.com/GalloDaSballo/ebtc-bsm/tree/fix-solidity-errors): updates the solidity version to use custom errors. (Missing some, please add them)


## Suggestions 
IMO you must fix the minted-rounding as to avoid having the fee round down to zero

Other checks are nice to haves

But IMO you should have revert messages for all functions (messages are ok, I personally prefer them over customErrors)
And you should test all those revert cases

CEI checks is important and we should ask Cergyk to re-check

The Excess withdraw is a very innocent fix, I think you should add it as well

## Missing changes

I did not fix the fuzz tests, please fix them @JulissaDantes 

I couldn't find revert tests, please consider adding them

## Invariant Tests

I've added explicit tests for fees not being sidesteppable

Run is here:
https://getrecon.xyz/dashboard/jobs/1ccc0309-f61b-4529-8344-0dc6d2284ac8